### PR TITLE
remove lasting listeners

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -21,8 +21,8 @@ meta:
 	ADDON_TAGS = "raspberry pi, video player"
 	ADDON_URL = https://github.com/jvcleave/ofxOMXPlayer
 
-common:
-	ADDON_PKG_CONFIG_LIBRARIES = libavcodec libavdevice libavfilter libavformat libavresample libavutil libpostproc libswresample libswscale
-	ADDON_INCLUDES = src 
-	ADDON_CFLAGS = -fPIC -U_FORTIFY_SOURCE -Wall -ftree-vectorize -ftree-vectorize -Wno-deprecated-declarations -Wno-sign-compare -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-but-set-variable
-	ADDON_LDFLAGS= -lavcodec -lavformat -lswscale -lavutil -lswresample -lavfilter -lm -lz
+#common:
+#	ADDON_PKG_CONFIG_LIBRARIES = libavcodec libavdevice libavfilter libavformat libavresample libavutil libpostproc libswresample libswscale
+#	ADDON_INCLUDES = src 
+#	ADDON_CFLAGS = -fPIC -U_FORTIFY_SOURCE -Wall -ftree-vectorize -ftree-vectorize -Wno-deprecated-declarations -Wno-sign-compare -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-but-set-variable
+#	ADDON_LDFLAGS= -lavcodec -lavformat -lswscale -lavutil -lswresample -lavfilter -lm -lz

--- a/src/linux/PlatformDefs.h
+++ b/src/linux/PlatformDefs.h
@@ -318,8 +318,15 @@ typedef struct _TIME_ZONE_INFORMATION {
 // Network
 #define SOCKADDR_IN struct sockaddr_in
 #define IN_ADDR struct in_addr
+
+#ifndef SOCKET_ERROR
 #define SOCKET_ERROR (-1)
+#endif
+
+#ifndef INVALID_SOCKET
 #define INVALID_SOCKET (~0)
+#endif
+
 #define closesocket(s)  close(s)
 #define ioctlsocket(s, f, v) ioctl(s, f, v)
 #define WSAGetLastError() (errno)

--- a/src/ofxOMXPlayer.cpp
+++ b/src/ofxOMXPlayer.cpp
@@ -30,7 +30,7 @@ ofxOMXPlayer::ofxOMXPlayer()
     imageFilters.push_back(ImageFilter("ColourBalance", OMX_ImageFilterColourBalance));
     imageFilters.push_back(ImageFilter("Cartoon", OMX_ImageFilterCartoon));
     
-    listener = NULL;
+    listener = nullptr;
     engineNeedsRestart = false;
     pendingLoopMessage = false;
     OMX_Init();
@@ -581,4 +581,9 @@ string ofxOMXPlayer::findFilterName(OMX_IMAGEFILTERTYPE filterType)
         
     }
     return result;
+}
+
+ofxOMXPlayer::~ofxOMXPlayer(){
+    ofRemoveListener(ofEvents().update, this, &ofxOMXPlayer::onUpdate);
+    listener = nullptr;
 }

--- a/src/ofxOMXPlayer.h
+++ b/src/ofxOMXPlayer.h
@@ -24,7 +24,7 @@ class ofxOMXPlayer : public EngineListener
 {
 public:
     
-    
+    ~ofxOMXPlayer();
     COMXCore omxCore;
     ofxOMXPlayerEngine engine;
     ofxOMXPlayerSettings settings;

--- a/src/ofxOMXPlayerEngine.cpp
+++ b/src/ofxOMXPlayerEngine.cpp
@@ -96,7 +96,7 @@ void ofxOMXPlayerEngine::clear()
     m_has_audio = false;
     //currentPlaybackSpeed = 0.0;
     hasNewFrame = false;
-    listener = NULL;
+    listener = nullptr;
     isOpen = false;
     duration = 0;
     totalNumFrames = 0;
@@ -1392,8 +1392,9 @@ void ofxOMXPlayerEngine::doExit()
 
 void ofxOMXPlayerEngine::close(bool clearTextures)//default clearTextures = false
 {
+    ofRemoveListener(ofEvents().update, this, &ofxOMXPlayerEngine::onUpdate);
+    listener = nullptr;
     lock();
-    //ofRemoveListener(ofEvents().update, this, &ofxOMXPlayerEngine::onUpdate);
     stopThread();
     //
     


### PR DESCRIPTION
Hello,
following issue #146 : 

I found a way to work flawlessly with creating and destructing massive amounts of omxPlayer objects.
creating was fine, but **deleting, creating again and loading videos on those overlapping one** crashed.

Hope it looks fine to you.