### PR TITLE
Added option to use specified OMXPlayerSettings in ofRPIVideoPlayer

### DIFF
--- a/src/ofRPIVideoPlayer.cpp
+++ b/src/ofRPIVideoPlayer.cpp
@@ -50,6 +50,12 @@ bool ofRPIVideoPlayer::load(string name)
     
 }
 
+bool ofRPIVideoPlayer::loadWithSettings(ofxOMXPlayerSettings newSettings)
+{
+    newSettings.listener = this;
+    return openOMXPlayer(newSettings);
+}
+
 bool ofRPIVideoPlayer::openOMXPlayer(ofxOMXPlayerSettings settings_)
 {
     settings = settings_;

--- a/src/ofRPIVideoPlayer.h
+++ b/src/ofRPIVideoPlayer.h
@@ -11,6 +11,7 @@ class ofRPIVideoPlayer: public ofBaseVideoPlayer, public ofxOMXPlayerListener
 public:
     ofRPIVideoPlayer();
     bool load(string name);
+    bool loadWithSettings(ofxOMXPlayerSettings newSettings);
     void loadAsync(string name);
     void play();
     void stop();


### PR DESCRIPTION
For a project, I needed to disable `ofxOMXPlayerSettings.useHDMIForAudio` while still maintaining partial compatibility with `ofBaseVideoPlayer` when using `ofRPIVideoPlayer`.

To accomplish this, I added a new function `ofRPIVideoPlayer::loadWithSettings(ofxOMXPlayerSettings newSettings)` which takes a `ofxOMXPlayerSettings` object. It follows the code pattern of `ofRPIVideoPlayer::load(string name)` to ensure compatibility.

Hope this looks good!