### PR TITLE
Seeking fix for seekToTimeInSeconds()

### DIFF
--- a/src/ofxOMXPlayerEngine.cpp
+++ b/src/ofxOMXPlayerEngine.cpp
@@ -1020,12 +1020,11 @@ void ofxOMXPlayerEngine::seekToFrame(int frameTarget)
     
 }
 
-void ofxOMXPlayerEngine::seekToTimeInSeconds(int timeInSeconds)
+void ofxOMXPlayerEngine::seekToTimeInSeconds(double timeInSeconds)
 {
     lock();
-    int seekTime = timeInSeconds%60;
     double oldPos = omxClock.OMXMediaTime()*1e-6;
-    m_incr = seekTime-oldPos;
+    m_incr = timeInSeconds-oldPos;
     ofLog() << "seekToTimeInSeconds: " << m_incr;
     unlock();
 }

--- a/src/ofxOMXPlayerEngine.h
+++ b/src/ofxOMXPlayerEngine.h
@@ -127,7 +127,7 @@ public:
     void onUpdate(ofEventArgs& eventArgs);
   
     void seekToFrame(int frameTarget);
-    void seekToTimeInSeconds(int timeInSeconds);
+    void seekToTimeInSeconds(double timeInSeconds);
     void increaseSpeed();
     void decreaseSpeed();
     void setNormalSpeed();


### PR DESCRIPTION
Seeking wasn't working properly due to some odd code in the seeking function.
I've altered the code to something more sensible which works fine.

Was this legacy code?

(ps: I closed my initial PR #160 as I've pushed this to a separate branch instead having it sit in master)